### PR TITLE
Add support for fields with arguments but without includes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
       "Tests\\": "tests/"
     }
   },
+  "scripts": {
+    "test": "phpunit tests/ --whitelist src/ --coverage-clover build/coverage/xml"
+},
   "require-dev": {
     "symfony/var-dumper": "^6.2",
     "squizlabs/php_codesniffer": "^3.7",

--- a/src/Parsers/NodeParser.php
+++ b/src/Parsers/NodeParser.php
@@ -27,13 +27,18 @@ class NodeParser implements ParserInterface
 
     public function parse(IsParsableInterface $parsable, bool $singleLine = false): string
     {
+        $includes = $this->parseAttributes($parsable)
+        . $this->parseFragments($parsable)
+        . $this->parseChildren($parsable);
+        if($includes) {
+            $includes = ' {' . PHP_EOL . $includes . PHP_EOL . '}' . PHP_EOL;
+        }
+
         return $parsable instanceof NodeInterface ?
             $this->strHelper->ugliffy(
-                $this->parseArguments($parsable)
-                . $this->parseAttributes($parsable)
-                . $this->parseFragments($parsable)
-                . $this->parseChildren($parsable)
-                . PHP_EOL . '}' . PHP_EOL,
+                $parsable->getName()
+                . $this->parseArguments($parsable)
+                .  $includes,
                 $singleLine
             ) :
             '';
@@ -42,8 +47,9 @@ class NodeParser implements ParserInterface
     protected function parseArguments(NodeInterface $parsable): string
     {
         return $parsable->hasArguments() ?
-            $parsable->getName() . '(' . $parsable->getArguments() . ') {' . PHP_EOL :
-            $parsable->getName() . ' {' . PHP_EOL;
+             '(' . $parsable->getArguments() . ') '
+             : '';
+
     }
 
     protected function parseAttributes(NodeInterface $parsable): string

--- a/tests/Unit/Actions/MutationTest.php
+++ b/tests/Unit/Actions/MutationTest.php
@@ -29,7 +29,7 @@ class MutationTest extends TestCase
     public function testMutation()
     {
         $mutation = new Mutation('fooBar', ['id' => 1, 'name' => 'bar']);
-        $this->assertEquals('mutation fooBar(id: 1 name: "bar") {}', $this->str->ugliffy($mutation->toString()));
+        $this->assertEquals('mutation fooBar(id: 1 name: "bar")', $this->str->ugliffy($mutation->toString()));
         $mutation->use('id', 'name');
         $this->assertEquals('mutation fooBar(id: 1 name: "bar") { id name }', $this->str->ugliffy($mutation->toString()));
         $mutation = new Mutation('fooBar2', ['name' => 'foo', 'test' => new Variable('bar', 'String')]);

--- a/tests/Unit/Actions/QueryTest.php
+++ b/tests/Unit/Actions/QueryTest.php
@@ -29,12 +29,12 @@ class QueryTest extends TestCase
     {
         $variable = new Variable('foo', 'String');
         $query = new Query('foo');
-        $this->assertEquals('{ foo {}}', $this->str->ugliffy($query->toString()));
+        $this->assertEquals('{ foo }', $this->str->ugliffy($query->toString()));
         $query->use('id', 'name');
         $this->assertEquals('{ foo { id name }}', $this->str->ugliffy($query->toString()));
         $query->allies(['name' => new Variable('name', 'String')]);
         $this->assertEquals(
-            'query getFoo($name: String){ foo { id name allies(name: $name) {}}}',
+            'query getFoo($name: String){ foo { id name allies(name: $name) }}',
             $this->str->ugliffy($query->toString())
         );
         $query->addVariable($variable);

--- a/tests/Unit/Entities/NodeTest.php
+++ b/tests/Unit/Entities/NodeTest.php
@@ -21,7 +21,6 @@ use GraphQL\Entities\Variable;
 use GraphQL\Exceptions\InvalidArgumentTypeException;
 use GraphQL\Exceptions\InvalidTypeOperationException;
 use GraphQL\Utils\Str;
-use phpDocumentor\Reflection\Types\Callable_;
 use PHPUnit\Framework\TestCase;
 use Tests\Unit\AssertExceptionTrait;
 
@@ -75,9 +74,9 @@ class NodeTest extends TestCase
         $this->assertTrue($node->hasArguments());
         $this->assertCount(2, $node->getArguments());
         $this->assertCount(1, $query->getVariables());
-        $this->assertEquals('foo(bar: true var: $var) {}', $this->str->ugliffy($node->toString()));
+        $this->assertEquals('foo(bar: true var: $var)', $this->str->ugliffy($node->toString()));
         $this->assertEquals(
-            'query getFoo($var: String){ foo { foo(bar: true var: $var) {}}}',
+            'query getFoo($var: String){ foo { foo(bar: true var: $var) }}',
             $this->str->ugliffy($query->toString())
         );
     }
@@ -101,7 +100,7 @@ class NodeTest extends TestCase
         $this->assertEquals('foo { ...bar }', $this->str->ugliffy($node->toString()));
         $node->removeFragment($fragment);
         $this->assertFalse($node->hasFragments());
-        $this->assertEquals('foo {}', $this->str->ugliffy($node->toString()));
+        $this->assertEquals('foo', $this->str->ugliffy($node->toString()));
         $node->on('foo')->use('bar');
         $this->assertEquals('foo { ... on foo { bar }}', $this->str->ugliffy($node->toString()));
     }
@@ -124,7 +123,7 @@ class NodeTest extends TestCase
         $this->assertEquals($root, $node->root());
         $this->assertEquals($root, $node->getRootNode());
         $node->bar2 = new Node('bar2');
-        $this->assertEquals('foo { bar2 {}}', $this->str->ugliffy($node->parse()));
+        $this->assertEquals('foo { bar2 }', $this->str->ugliffy($node->parse()));
         $node->clear();
         $this->assertCount(0, $node->getChildren());
         $this->assertThrowsException(fn() => $node->bar2(), InvalidArgumentTypeException::class, 'Invalid argument type You must pass an Array as param 0');
@@ -139,7 +138,7 @@ class NodeTest extends TestCase
     public function testParseability()
     {
         $node = new Node('foo');
-        $this->assertEquals('foo {}', $this->str->ugliffy($node->parse()));
+        $this->assertEquals('foo', $this->str->ugliffy($node->parse()));
         $node->use('uuid', 'name');
         $this->assertEquals('foo { uuid name }', $this->str->ugliffy($node->parse()));
         $node->on('bar')->use('catch');


### PR DESCRIPTION
I implemented a fix that allows using fields with arguments, but without includes (sub-fields), to fix the issue #31.

An example of queries without sub-fields can be found in the Commercetools GraphQL API here: https://docs.commercetools.com/api/graphql
```graphql
                masterData {
                  current {
                    slug(locale: "en")
                  }
                }
```

Also, I added the `composer test` command to simplify running tests.

Please review it and tell me if something needs to be reworked.